### PR TITLE
Change min-height of poem slide to 100% of parent

### DIFF
--- a/css/roulette.css
+++ b/css/roulette.css
@@ -248,7 +248,7 @@ body {
     min-width: 100%;
     height: auto;
     padding-bottom: 80px;
-    min-height: 700px
+    min-height: 100%
 }
 
 .circleContainer,


### PR DESCRIPTION
- Fix CSS issues with background screen appearing in case of short poems or smaller screen resolution. 